### PR TITLE
Fix duplicate symbol errors on LLVM (MacOS)

### DIFF
--- a/php_weakref.c
+++ b/php_weakref.c
@@ -29,6 +29,12 @@
 #include "wr_weakmap.h"
 #include "php_weakref.h"
 
+#ifdef ZTS
+int weakref_globals_id;
+#else
+zend_weakref_globals weakref_globals;
+#endif
+
 void wr_store_init(TSRMLS_D) /* {{{ */
 {
 	wr_store *store = emalloc(sizeof(wr_store));

--- a/php_weakref.h
+++ b/php_weakref.h
@@ -75,10 +75,10 @@ void wr_store_attach(zend_object *intern, wr_ref_dtor dtor, zval *ref TSRMLS_DC)
 
 #ifdef ZTS
 #define WR_G(v) TSRMG(weakref_globals_id, zend_weakref_globals *, v)
-int weakref_globals_id;
+extern int weakref_globals_id;
 #else
 #define WR_G(v) (weakref_globals.v)
-zend_weakref_globals weakref_globals;
+extern zend_weakref_globals weakref_globals;
 #endif
 
 #endif /* PHP_WEAKREF_H */

--- a/wr_weakmap.c
+++ b/wr_weakmap.c
@@ -31,6 +31,9 @@
 #include "wr_weakmap.h"
 #include "php_weakref.h"
 
+zend_object_handlers wr_handler_WeakMap;
+WEAKREF_API zend_class_entry  *wr_ce_WeakMap;
+
 
 static void wr_weakmap_ref_dtor(void *ref_object, zend_object_handle ref_handle, zend_object *wref_obj TSRMLS_DC) { /* {{{ */
 	wr_weakmap_object *intern = (wr_weakmap_object *)wref_obj;

--- a/wr_weakmap.h
+++ b/wr_weakmap.h
@@ -36,9 +36,6 @@ typedef struct _wr_weakmap_object {
 
 extern WEAKREF_API zend_class_entry *wr_ce_WeakMap;
 
-zend_object_handlers wr_handler_WeakMap;
-WEAKREF_API zend_class_entry  *wr_ce_WeakMap;
-
 #endif /* WR_WEAKMAP_H */
 
 /*

--- a/wr_weakref.c
+++ b/wr_weakref.c
@@ -29,6 +29,9 @@
 #include "wr_weakref.h"
 #include "php_weakref.h"
 
+zend_object_handlers wr_handler_WeakRef;
+WEAKREF_API zend_class_entry  *wr_ce_WeakRef;
+
 
 static void wr_weakref_ref_dtor(void *ref_object, zend_object_handle ref_handle, zend_object *wref_obj TSRMLS_DC) { /* {{{ */
 	wr_weakref_object *wref = (wr_weakref_object *)wref_obj;

--- a/wr_weakref.h
+++ b/wr_weakref.h
@@ -32,9 +32,6 @@ typedef struct _wr_weakref_object {
 
 extern WEAKREF_API zend_class_entry *wr_ce_WeakRef;
 
-zend_object_handlers wr_handler_WeakRef;
-WEAKREF_API zend_class_entry  *wr_ce_WeakRef;
-
 #endif /* WR_WEAKREF_H */
 
 /*


### PR DESCRIPTION
With the variable definitions being in the header files and included from both wr_weakref/wr_weakmap and php_weakref, there are several duplicate symbol errors that aren't automatically resolved with llvm:

duplicate symbol _wr_ce_WeakRef in:
    .libs/php_weakref.o
    .libs/wr_weakref.o
duplicate symbol _wr_handler_WeakRef in:
    .libs/php_weakref.o
    .libs/wr_weakref.o
duplicate symbol _weakref_globals in:
    .libs/php_weakref.o
    .libs/wr_weakref.o
duplicate symbol _wr_ce_WeakMap in:
    .libs/php_weakref.o
    .libs/wr_weakmap.o
duplicate symbol _wr_handler_WeakMap in:
    .libs/php_weakref.o
    .libs/wr_weakmap.o
duplicate symbol _wr_handler_WeakRef in:
    .libs/php_weakref.o
    .libs/wr_weakmap.o
duplicate symbol _wr_ce_WeakRef in:
    .libs/php_weakref.o
    .libs/wr_weakmap.o
duplicate symbol _weakref_globals in:
    .libs/php_weakref.o
    .libs/wr_weakmap.o
