### PR TITLE
Fix max PHP version on PECL

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -47,7 +47,7 @@ http://pear.php.net/dtd/package-2.0.xsd">
   <required>
    <php>
     <min>5.3.0</min>
-    <max>5.6.0</max>
+    <max>5.6.1</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>


### PR DESCRIPTION
Installing this extension from PECL on PHP 5.6.1 throws:

> pecl/Weakref requires PHP (version >= 5.3.0, version <= 5.6.0, excluded versions: 6.0.0), installed version is 5.6.1
