### PR TITLE
fix segfault in wr_store_tracked_object_dtor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@ configure
 config.log
 config.guess
 run-tests.php
+tmp-php.ini
 config.h
 config.sub
 ltmain.sh
+ltmain.sh.backup
 Makefile.fragments
 Makefile.objects
 modules

--- a/tests/weakref_007.phpt
+++ b/tests/weakref_007.phpt
@@ -41,6 +41,13 @@ Weakref: Destroying the weakref and its object after a fatal error
 	}
 ?>
 --EXPECTF--
+Destroy A
+Destroy B
+bool(false)
 
-Fatal error: Call to undefined function crash() in %s on line %d
+Fatal error: Uncaught Error: Call to undefined function crash() in %s:%d
+Stack trace:
+#0 %s(%d): doit()
+#1 {main}
+  thrown in %s on line %d
 Exit: 255

--- a/wr_store.c
+++ b/wr_store.c
@@ -135,8 +135,12 @@ void wr_store_untrack(zend_object *wref_obj, zend_object *ref_obj) /* {{{ */
 
 		if (prev) {
 			prev->next = cur->next;
-		} else {
+		} else if (cur->next) {
 			zend_hash_index_update_ptr(&store->objs, ref_obj->handle, cur->next);
+		} else {
+			zend_object_dtor_obj_t     orig_dtor  = zend_hash_index_find_ptr(&store->old_dtors, (ulong)ref_obj->handlers);
+			((zend_object_handlers *)ref_obj->handlers)->dtor_obj = orig_dtor;
+			zend_hash_index_del(&store->objs, (ulong)ref_obj->handle);
 		}
 
 		efree(cur);


### PR DESCRIPTION
With this fix, build and test suite OK (except weakref_007.phpt which seems outdated, see 3rd commit)

I think it make sense, when no more track, to restore the old dtor (which was altered on first track), thus  wr_store_tracked_object_dtor is no more called.

But perhaps I have not enough knowledge of this extension internals ;)
